### PR TITLE
[READY] Fix progressView offset in Kiosk

### DIFF
--- a/Examples/PSPDFCatalog/Kiosk/PSCImageGridViewCell.m
+++ b/Examples/PSPDFCatalog/Kiosk/PSCImageGridViewCell.m
@@ -95,7 +95,6 @@ static void PSPDFDispatchIfNotOnMainThread(dispatch_block_t block) {
 
     // image darkener.
     self.progressViewBackground.frame = self.imageView.bounds;
-    self.progressView.frame = self.imageView.bounds;
 
     self.selectedBackgroundView.frame = CGRectInset(self.imageView.frame, -4.f, -4.f);
 }


### PR DESCRIPTION
progressView's frame is initially correctly set.
Later on it get's set to a wrong value.

Fixes PSPDFKit/PSPDFKit#1878