### PR TITLE
[READY] Don't create duplicates in Kiosk

### DIFF
--- a/Examples/PSPDFCatalog/Kiosk/PSCStoreManager.m
+++ b/Examples/PSPDFCatalog/Kiosk/PSCStoreManager.m
@@ -267,7 +267,7 @@ static char PSCKVOToken;
 
         [delegate magazineStoreBeginUpdate];
 
-        for (PSCMagazine *magazine in magazines) {
+        for (PSCMagazine *magazine in newMagazines) {
             PSCMagazineFolder *folder = [self addMagazineToFolder:magazine];
 
             // folder fresh or updated?

--- a/Examples/PSPDFCatalog/Kiosk/PSCStoreManager.m
+++ b/Examples/PSPDFCatalog/Kiosk/PSCStoreManager.m
@@ -345,10 +345,6 @@ static char PSCKVOToken;
     NSString *sampleFolder = [NSBundle.mainBundle.resourcePath stringByAppendingPathComponent:@"Samples"];
     [folders addObjectsFromArray:[self searchFolder:sampleFolder]];
 
-    // Add downloaded files
-    NSString *dirPath = [PSCStoreManager.storagePath stringByAppendingPathComponent:@"downloads"];
-    [folders addObjectsFromArray:[self searchFolder:dirPath]];
-
     // Add files from Open In...
     NSString *documentsFolder = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES).firstObject;
     [folders addObjectsFromArray:[self searchFolder:documentsFolder]];


### PR DESCRIPTION
This PR fixes a crash, which is caused by trying to remove duplicates in the Kiosk.
Not adding duplicates in the first place fixes the crash, obviously :)